### PR TITLE
Refresh CI lint coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -31,8 +31,8 @@ jobs:
 
       - name: Lint
         run: |
-          python -m ruff check ghost tests
-          python -m ruff format --check ghost tests
+          python -m ruff check ghost tests conftest.py
+          python -m ruff format --check ghost tests conftest.py
 
       - name: Test
         run: python -m pytest -q

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,4 @@
 import sys
 import os
+
 sys.path.insert(0, os.path.dirname(__file__))


### PR DESCRIPTION
## Summary
- include conftest.py in Ruff CI checks
- apply Ruff formatting to conftest.py
- update GitHub Actions to checkout v6 and setup-python v6 to avoid Node 20 runner deprecation warnings

## Verification
- .venv/bin/python -m ruff check ghost tests conftest.py
- .venv/bin/python -m ruff format --check ghost tests conftest.py
- .venv/bin/python -m pytest -q