### PR TITLE
Calibrate username platform claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 | Capability | Ghost | Maltego | SpiderFoot | Recon-ng |
 |---|:---:|:---:|:---:|:---:|
 | **AI-Powered Correlation** | ✅ | ❌ | ❌ | ❌ |
-| **75+ Built-in Username Checks** | ✅ | ✅¹ | ✅ | ~100 |
+| **70+ Built-in Username Checks** | ✅ | ✅¹ | ✅ | ~100 |
 | **SQLite Case Files & Provenance** | ✅ | ❌ | ✅ | ❌ |
 | **Professional HTML/PDF Reports** | ✅ | ✅ | ✅ | ❌ |
 | **Web Dashboard with Graphs** | ✅ | ✅ | ✅ | ❌ |
@@ -54,7 +54,7 @@
 
 | Module | Description | Status |
 |---|---|:---:|
-| 🔤 **Username Enumeration** | Check 75+ built-in platforms; optional Sherlock expands coverage | ✅ |
+| 🔤 **Username Enumeration** | Check 70+ built-in platforms; optional Sherlock expands coverage | ✅ |
 | 📧 **Email Intelligence** | Breach checks, account discovery, WHOIS, validation | ✅ |
 | 📱 **Phone OSINT** | Carrier lookup, location, social media association | ✅ |
 | 🌐 **Domain Recon** | WHOIS, DNS, subdomains, tech stack, SSL, Wayback | ✅ |

--- a/ghost/modules/username.py
+++ b/ghost/modules/username.py
@@ -1,4 +1,4 @@
-"""Username enumeration across 500+ platforms."""
+"""Username enumeration across 70+ built-in platforms."""
 
 import asyncio
 import aiohttp


### PR DESCRIPTION
## Summary
- align the README username-check count with the current built-in platform list
- replace the stale `500+ platforms` username-module docstring with the current 70+ built-in coverage

## Why
The repository description currently advertises 500+ platform checks, but the built-in username platform list has 70 entries. Keeping the in-repo claims conservative reduces overclaim/reputation risk while still noting that Sherlock can expand coverage separately.

## Verification
- `.venv/bin/python -m ruff check ghost tests conftest.py`
- `.venv/bin/python -m ruff format --check ghost tests`
- `.venv/bin/python -m pytest -q`
- `git diff --check`

Note: `.venv/bin/python -m ruff format --check ghost tests conftest.py` still reports the existing `conftest.py` formatting issue that PR #8 already fixes; this branch leaves that separate PR untouched.
