### PR TITLE
Return a failure status from doctor checks

### DIFF
--- a/ghost/ui/cli.py
+++ b/ghost/ui/cli.py
@@ -17,7 +17,7 @@ from rich import box
 
 from ghost.core.investigator import GhostInvestigator
 from ghost.core.config import config
-from ghost.core.doctor import run_doctor_checks, summarize_doctor_checks
+from ghost.core.doctor import has_error, run_doctor_checks, summarize_doctor_checks
 from ghost.backend.db import (
     delete_investigation,
     get_graph_data,
@@ -129,6 +129,8 @@ def doctor(as_json):
 
     if as_json:
         click.echo(json.dumps(summarize_doctor_checks(checks), indent=2))
+        if has_error(checks):
+            raise click.exceptions.Exit(1)
         return
 
     print_banner()
@@ -145,6 +147,8 @@ def doctor(as_json):
     for check in checks:
         add(check.name, check.ok, check.detail, check.severity)
     console.print(table)
+    if has_error(checks):
+        raise click.exceptions.Exit(1)
 
 
 @cli.command(name="list")

--- a/tests/test_investigator.py
+++ b/tests/test_investigator.py
@@ -252,6 +252,38 @@ class TestDatabaseConfiguration:
         assert "checks" in payload
         assert "Ghost Doctor" not in result.output
 
+    def test_doctor_cli_json_exits_nonzero_on_hard_error(self, monkeypatch):
+        from click.testing import CliRunner
+        from ghost.core.doctor import DoctorCheck
+        from ghost.ui import cli as cli_module
+
+        monkeypatch.setattr(
+            cli_module,
+            "run_doctor_checks",
+            lambda: [DoctorCheck("database", False, "unavailable", "error")],
+        )
+
+        result = CliRunner().invoke(cli_module.cli, ["doctor", "--json"])
+
+        assert result.exit_code == 1
+        assert json.loads(result.output)["ok"] is False
+
+    def test_doctor_cli_human_output_exits_nonzero_on_hard_error(self, monkeypatch):
+        from click.testing import CliRunner
+        from ghost.core.doctor import DoctorCheck
+        from ghost.ui import cli as cli_module
+
+        monkeypatch.setattr(
+            cli_module,
+            "run_doctor_checks",
+            lambda: [DoctorCheck("database", False, "unavailable", "error")],
+        )
+
+        result = CliRunner().invoke(cli_module.cli, ["doctor"])
+
+        assert result.exit_code == 1
+        assert "FAIL" in result.output
+
     def test_doctor_reports_unsupported_database_override(self):
         from ghost.core.config import Config
         from ghost.core.doctor import has_error, run_doctor_checks, summarize_doctor_checks


### PR DESCRIPTION
## What changed

- make `ghost doctor` return exit status 1 when a hard-error check fails
- preserve both JSON and human-readable output before exiting
- cover both CLI output modes with regression tests

## Why

Hard-error doctor checks were rendered correctly but still returned a successful process status, so scripts could not distinguish healthy output from a failed diagnostic.

## Proof

- [x] `.venv/bin/python -m ruff check ghost tests`
- [x] `.venv/bin/python -m ruff format --check ghost tests`
- [x] `.venv/bin/python -m pytest -q` (59 passed)
- [x] Terminal output behavior is covered in `tests/test_investigator.py`

## Safety

- [x] This supports authorized security research, journalism, law enforcement, or self-audits
- [x] No private target data, secrets, generated databases, reports, or investigation artifacts are committed
- [x] No new collection behavior is introduced
